### PR TITLE
 	fix NPE when DiscoveryMode.MANUAL and no ClientSideCallContext given to stub method

### DIFF
--- a/distributeme-generator/src/main/java/org/distributeme/generator/StubGenerator.java
+++ b/distributeme-generator/src/main/java/org/distributeme/generator/StubGenerator.java
@@ -256,6 +256,9 @@ public class StubGenerator extends AbstractStubGenerator implements Generator{
 			writeStatement("boolean abortAndFail = false");
 			writeString("if (diMeCallContext == null)");
 			writeIncreasedStatement("diMeCallContext = new ClientSideCallContext("+quote(method.getSimpleName())+")");
+			writeString("if (discoveryMode == DiscoveryMode.MANUAL) {");
+			writeIncreasedStatement("diMeCallContext.setServiceId(manuallySetDescriptor.getServiceId())");
+			writeString("}");
 			writeString("if (discoveryMode==DiscoveryMode.AUTO && diMeCallContext.getServiceId()==null)");
 			writeIncreasedStatement("diMeCallContext.setServiceId("+getConstantsName(type)+".getServiceId())");
 			emptyline();


### PR DESCRIPTION
NullPointerException when using EventService with enabled QOSMonitoringInterceptor 

In "RemoteEventServiceRMIBridgeServiceStub.getInstanceId(...)" no serviceId is set when ClientSideCallContext parameter is null. It seams that, the default case is: discoveryMode is set to DiscoveryMode.MANUAL and given ClientSideCallContext is always null. So no serviceId is ever set to the context object and this leads to the following exception:

ERROR 2015-07-19 23:08:06,840 [localhost-startStop-1] net.anotheria.anoprise.eventservice.EventServiceImpl - Unexcepted exception in listener org.distributeme.support.eventservice.DiMeRemoteEventChannelRMISupport@238d03ec, in call notifyChannelCreation(SearchServiceChannel, PUSH_SUPPLIER_PROXY)
java.lang.NullPointerException: null
        at java.util.concurrent.ConcurrentHashMap.hash(ConcurrentHashMap.java:333) ~[na:1.7.0_79]
        at java.util.concurrent.ConcurrentHashMap.containsKey(ConcurrentHashMap.java:1016) ~[na:1.7.0_79]
        at org.distributeme.core.qos.QOSRegistry.callStarted(QOSRegistry.java:76) ~[distributeme-core-2.2.1.jar:2.2.1]
        at org.distributeme.core.qos.QOSMonitoringInterceptor.beforeServiceCall(QOSMonitoringInterceptor.java:32) ~[distributeme-core-2.2.1.jar:2.2.1]
        at org.distributeme.support.eventservice.generated.RemoteEventServiceRMIBridgeServiceStub.getInstanceId(RemoteEventServiceRMIBridgeServiceStub.java:491) ~[distributeme-support-2.2.1.jar:2.2.1]
        at org.distributeme.support.eventservice.generated.RemoteEventServiceRMIBridgeServiceStub.getInstanceId(RemoteEventServiceRMIBridgeServiceStub.java:465) ~[distributeme-support-2.2.1.jar:2.2.1]
        at org.distributeme.support.eventservice.DiMeRemoteEventChannelRMISupport.localSupplierProxyCreated(DiMeRemoteEventChannelRMISupport.java:179) ~[distributeme-support-2.2.1.jar:2.2.1]
        at org.distributeme.support.eventservice.DiMeRemoteEventChannelRMISupport.channelCreated(DiMeRemoteEventChannelRMISupport.java:71) ~[distributeme-support-2.2.1.jar:2.2.1]
        at net.anotheria.anoprise.eventservice.EventServiceImpl.notifyChannelCreation(EventServiceImpl.java:217) [ano-prise-2.1.0.jar:2.1.0]
        at net.anotheria.anoprise.eventservice.EventServiceImpl._obtainPushSupplierProxy(EventServiceImpl.java:136) [ano-prise-2.1.0.jar:2.1.0]
        at net.anotheria.anoprise.eventservice.EventServiceImpl.obtainEventChannel(EventServiceImpl.java:82) [ano-prise-2.1.0.jar:2.1.0]
