### PR TITLE
Implement test for RoutingStats problems 

### DIFF
--- a/distributeme-core/src/main/java/org/distributeme/core/routing/AbstractRouterWithStickyFailOverToNextNode.java
+++ b/distributeme-core/src/main/java/org/distributeme/core/routing/AbstractRouterWithStickyFailOverToNextNode.java
@@ -87,7 +87,7 @@ public abstract class AbstractRouterWithStickyFailOverToNextNode extends Abstrac
 		}
 
 
-		String selectedServiceId = null;
+		String selectedServiceId;
 
 		switch (getStrategy()) {
 			case MOD_ROUTER:
@@ -137,7 +137,7 @@ public abstract class AbstractRouterWithStickyFailOverToNextNode extends Abstrac
 		String originalServiceId = context.getServiceId();
 		HashSet<String> instancesThatIAlreadyTried = (HashSet<String>)context.getTransportableCallContext().get(ATTR_TRIED_INSTANCES);
 		if (instancesThatIAlreadyTried==null){
-			instancesThatIAlreadyTried = new HashSet<String>();
+			instancesThatIAlreadyTried = new HashSet<>();
 			context.getTransportableCallContext().put(ATTR_TRIED_INSTANCES, instancesThatIAlreadyTried);
 		}
 

--- a/distributeme-core/src/main/java/org/distributeme/core/routing/AbstractRouterWithStickyFailOverToNextNode.java
+++ b/distributeme-core/src/main/java/org/distributeme/core/routing/AbstractRouterWithStickyFailOverToNextNode.java
@@ -62,7 +62,7 @@ public abstract class AbstractRouterWithStickyFailOverToNextNode extends Abstrac
 	/** {@inheritDoc} */
 	@Override
 	public FailDecision callFailed(final ClientSideCallContext clientSideCallContext) {
-		getLog().info(clientSideCallContext.getServiceId()+ " marked as failed and will be blacklisted for "+getConfiguration().getBlacklistTime()+" ms");
+		getLog().info(clientSideCallContext.getServiceId()+ " marked as failed");
 
 		blacklistingStrategy.notifyCallFailed(clientSideCallContext);
 		return super.callFailed(clientSideCallContext);

--- a/distributeme-core/src/main/java/org/distributeme/core/routing/AbstractRouterWithStickyFailOverToNextNode.java
+++ b/distributeme-core/src/main/java/org/distributeme/core/routing/AbstractRouterWithStickyFailOverToNextNode.java
@@ -173,7 +173,7 @@ public abstract class AbstractRouterWithStickyFailOverToNextNode extends Abstrac
 				}
 			}
 			//now pick a candidate
-			int candidate = candidates[random.nextInt(candidates.length)];
+			int candidate = candidates[getRandomInt(candidates.length)];
 			result = originalServiceId.substring(0, lastUnderscore + 1) + candidate;
 		}
 
@@ -193,6 +193,9 @@ public abstract class AbstractRouterWithStickyFailOverToNextNode extends Abstrac
 
 	}
 
+	protected int getRandomInt(final int length) {
+		return random.nextInt(length);
+	}
 
 
 	/** {@inheritDoc} */

--- a/distributeme-core/src/main/java/org/distributeme/core/routing/blacklisting/DefaultBlacklistingStrategy.java
+++ b/distributeme-core/src/main/java/org/distributeme/core/routing/blacklisting/DefaultBlacklistingStrategy.java
@@ -5,6 +5,8 @@ import java.util.concurrent.ConcurrentMap;
 
 import org.distributeme.core.ClientSideCallContext;
 import org.distributeme.core.routing.GenericRouterConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -21,6 +23,7 @@ public class DefaultBlacklistingStrategy implements BlacklistingStrategy {
 	 */
 	private ConcurrentMap<String, Long> serverFailureTimestamps = new ConcurrentHashMap<String, Long>();
 	private GenericRouterConfiguration configuration;
+	private Logger logger = LoggerFactory.getLogger(DefaultBlacklistingStrategy.class);
 
 	@Override
 	public boolean isBlacklisted(String instanceId) {
@@ -30,6 +33,7 @@ public class DefaultBlacklistingStrategy implements BlacklistingStrategy {
 
 	@Override
 	public void notifyCallFailed(ClientSideCallContext clientSideCallContext) {
+		logger.info(clientSideCallContext.getServiceId()+ " will be blacklisted for "+configuration.getBlacklistTime()+" ms");
 		serverFailureTimestamps.put(clientSideCallContext.getServiceId(), System.currentTimeMillis());
 	}
 

--- a/distributeme-core/src/main/java/org/distributeme/core/routing/blacklisting/DefaultBlacklistingStrategy.java
+++ b/distributeme-core/src/main/java/org/distributeme/core/routing/blacklisting/DefaultBlacklistingStrategy.java
@@ -21,7 +21,7 @@ public class DefaultBlacklistingStrategy implements BlacklistingStrategy {
 	/**
 	 * Map with timestamps for last server failures.
 	 */
-	private ConcurrentMap<String, Long> serverFailureTimestamps = new ConcurrentHashMap<String, Long>();
+	private ConcurrentMap<String, Long> serverFailureTimestamps = new ConcurrentHashMap<>();
 	private GenericRouterConfiguration configuration;
 	private Logger logger = LoggerFactory.getLogger(DefaultBlacklistingStrategy.class);
 

--- a/distributeme-core/src/test/java/org/distributeme/core/routing/AbstractRouterWithStickyFailOverToNextNodeTest.java
+++ b/distributeme-core/src/test/java/org/distributeme/core/routing/AbstractRouterWithStickyFailOverToNextNodeTest.java
@@ -42,6 +42,7 @@ public class AbstractRouterWithStickyFailOverToNextNodeTest {
 
 	@Test
 	public void callFailed_CalculatesTheRoutingStatsCorrect() throws Exception {
+		routerWithStickyFailOverToNextNode.setConfigurationName("myService", "blacklisting-routing-test-empty");
 		String serviceId = "myService";
 		ClientSideCallContext clientSideCallContext = new ClientSideCallContext(serviceId, "test", Collections.emptyList());
 		routerWithStickyFailOverToNextNode.callFailed(clientSideCallContext);

--- a/distributeme-core/src/test/java/org/distributeme/core/routing/AbstractRouterWithStickyFailOverToNextNodeTest.java
+++ b/distributeme-core/src/test/java/org/distributeme/core/routing/AbstractRouterWithStickyFailOverToNextNodeTest.java
@@ -1,12 +1,18 @@
 package org.distributeme.core.routing;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.distributeme.core.ClientSideCallContext;
 import org.distributeme.core.routing.blacklisting.DefaultBlacklistingStrategy;
 import org.distributeme.core.routing.blacklisting.NoOpBlacklistingStrategy;
-import org.junit.Before;
+import org.distributeme.core.stats.RoutingStatsCollector;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
 
 
 /**
@@ -34,7 +40,154 @@ public class AbstractRouterWithStickyFailOverToNextNodeTest {
 		assertTrue("Router not of specified clazz", routerWithStickyFailOverToNextNode.getBlacklistingStrategy() instanceof DefaultBlacklistingStrategy);
 	}
 
+	@Test
+	public void callFailed_CalculatesTheRoutingStatsCorrect() throws Exception {
+		String serviceId = "myService";
+		ClientSideCallContext clientSideCallContext = new ClientSideCallContext(serviceId, "test", Collections.emptyList());
+		routerWithStickyFailOverToNextNode.callFailed(clientSideCallContext);
+
+		RoutingStatsCollectorForTest routingStats = (RoutingStatsCollectorForTest) routerWithStickyFailOverToNextNode.getRoutingStats(serviceId);
+
+		assertThat(routingStats.getFailedCall(), is(1));
+		assertThat(routingStats.getFailedDecision(), is(1));
+		assertThat(routingStats.getRetryDecision(), is(0));
+		assertThat(routingStats.getRequestRoutedTo(), is(0));
+		assertThat(routingStats.getBlacklisted(), is(0));
+	}
+
+	@Test
+	public void getServiceIdForCall_CalculatesTheRoutingStatsCorrect_WithServiceAmountZero() throws Exception {
+		String serviceId = "myService";
+		ClientSideCallContext clientSideCallContext = new ClientSideCallContext(serviceId, "test", Collections.emptyList());
+		String resultServiceId = routerWithStickyFailOverToNextNode.getServiceIdForCall(clientSideCallContext);
+
+		RoutingStatsCollectorForTest routingStats = (RoutingStatsCollectorForTest) routerWithStickyFailOverToNextNode.getRoutingStats(resultServiceId);
+
+		assertThat(resultServiceId, is(serviceId));
+		assertThat(routingStats.getFailedCall(), is(0));
+		assertThat(routingStats.getFailedDecision(), is(0));
+		assertThat(routingStats.getRetryDecision(), is(0));
+		assertThat(routingStats.getRequestRoutedTo(), is(1));
+		assertThat(routingStats.getBlacklisted(), is(0));
+	}
+
+	@Test
+	public void getServiceIdForCall_CalculatesTheRoutingStatsCorrect_WithOneService() throws Exception {
+		routerWithStickyFailOverToNextNode.setConfigurationName("someServiceId", "blacklisting-routing-test-regular");
+
+		String serviceId = "myService";
+		ClientSideCallContext clientSideCallContext = new ClientSideCallContext(serviceId, "test", Collections.emptyList());
+		String resultServiceId = routerWithStickyFailOverToNextNode.getServiceIdForCall(clientSideCallContext);
+
+		RoutingStatsCollectorForTest routingStats = (RoutingStatsCollectorForTest) routerWithStickyFailOverToNextNode.getRoutingStats(resultServiceId);
+
+		assertThat(resultServiceId, is(serviceId + "_0"));
+		assertThat(routingStats.getFailedCall(), is(0));
+		assertThat(routingStats.getFailedDecision(), is(0));
+		assertThat(routingStats.getRetryDecision(), is(0));
+		assertThat(routingStats.getRequestRoutedTo(), is(1));
+		assertThat(routingStats.getBlacklisted(), is(0));
+	}
+
+	@Test
+	public void getServiceIdForCall_CalculatesTheRoutingStatsCorrect_WithTwoServiceAndFirstIsBlacklistedButRequestGoesToOtherOne() throws Exception {
+		routerWithStickyFailOverToNextNode.setConfigurationName("someServiceId", "blacklisting-routing-test-two-services");
+
+		String serviceIdFailed = "myService_0";
+		ClientSideCallContext failedContext = new ClientSideCallContext(serviceIdFailed, "test", Collections.emptyList());
+		routerWithStickyFailOverToNextNode.callFailed(failedContext);
+
+		String serviceId = "myService";
+		ClientSideCallContext clientSideCallContext = new ClientSideCallContext(serviceId, "test", Collections.emptyList());
+		String resultServiceId = routerWithStickyFailOverToNextNode.getServiceIdForCall(clientSideCallContext);
+
+		assertThat(resultServiceId, is(serviceId + "_1"));
+
+		RoutingStatsCollectorForTest routingStatsService0 = (RoutingStatsCollectorForTest) routerWithStickyFailOverToNextNode.getRoutingStats(serviceIdFailed);
+		assertThat(routingStatsService0.getFailedCall(), is(1));
+		assertThat(routingStatsService0.getFailedDecision(), is(1));
+		assertThat(routingStatsService0.getRetryDecision(), is(0));
+		assertThat(routingStatsService0.getRequestRoutedTo(), is(0));
+		assertThat(routingStatsService0.getBlacklisted(), is(0));
+
+		RoutingStatsCollectorForTest routingStatsService1 = (RoutingStatsCollectorForTest) routerWithStickyFailOverToNextNode.getRoutingStats(resultServiceId);
+		assertThat(routingStatsService1.getFailedCall(), is(0));
+		assertThat(routingStatsService1.getFailedDecision(), is(0));
+		assertThat(routingStatsService1.getRetryDecision(), is(0));
+		assertThat(routingStatsService1.getRequestRoutedTo(), is(1));
+		assertThat(routingStatsService1.getBlacklisted(), is(0));
+	}
+
+	@Test
+	public void getServiceIdForCall_CalculatesTheRoutingStatsCorrect_WithTwoServiceAndRequestGoesToBlacklistedService() throws Exception {
+		routerWithStickyFailOverToNextNode.setConfigurationName("someServiceId", "blacklisting-routing-test-two-services");
+
+		String serviceIdFailed = "myService_1";
+		ClientSideCallContext failedContext = new ClientSideCallContext(serviceIdFailed, "test", Collections.emptyList());
+		routerWithStickyFailOverToNextNode.callFailed(failedContext);
+
+		String serviceId = "myService";
+		ClientSideCallContext clientSideCallContext = new ClientSideCallContext(serviceId, "test", Collections.emptyList());
+		String resultServiceId = routerWithStickyFailOverToNextNode.getServiceIdForCall(clientSideCallContext);
+		assertThat(resultServiceId, is(serviceId + "_0"));
+
+		RoutingStatsCollectorForTest routingStatsService1 = (RoutingStatsCollectorForTest) routerWithStickyFailOverToNextNode.getRoutingStats(serviceIdFailed);
+		assertThat(routingStatsService1.getFailedCall(), is(1));
+		assertThat(routingStatsService1.getFailedDecision(), is(1));
+		assertThat(routingStatsService1.getRetryDecision(), is(0));
+		assertThat(routingStatsService1.getRequestRoutedTo(), is(0));
+		assertThat(routingStatsService1.getBlacklisted(), is(1));
+
+		RoutingStatsCollectorForTest routingStatsService0 = (RoutingStatsCollectorForTest) routerWithStickyFailOverToNextNode.getRoutingStats(resultServiceId);
+		assertThat(routingStatsService0.getFailedCall(), is(0));
+		assertThat(routingStatsService0.getFailedDecision(), is(0));
+		assertThat(routingStatsService0.getRetryDecision(), is(0));
+		assertThat(routingStatsService0.getRequestRoutedTo(), is(1));
+		assertThat(routingStatsService0.getBlacklisted(), is(0));
+	}
+
+	@Test
+	public void getServiceIdForCall_CalculatesTheRoutingStatsCorrect_WithThreeServiceAndRequestGoesToBlacklistedService() throws Exception {
+		routerWithStickyFailOverToNextNode.setConfigurationName("someServiceId", "blacklisting-routing-test-three-services");
+
+		String serviceIdFailed1 = "myService_1";
+		ClientSideCallContext failedContext1 = new ClientSideCallContext(serviceIdFailed1, "test", Collections.emptyList());
+		routerWithStickyFailOverToNextNode.callFailed(failedContext1);
+
+		String serviceIdFailed2 = "myService_2";
+		ClientSideCallContext failedContext2 = new ClientSideCallContext(serviceIdFailed2, "test", Collections.emptyList());
+		routerWithStickyFailOverToNextNode.callFailed(failedContext2);
+
+		String serviceId = "myService";
+		ClientSideCallContext clientSideCallContext = new ClientSideCallContext(serviceId, "test", Collections.emptyList());
+		String resultServiceId = routerWithStickyFailOverToNextNode.getServiceIdForCall(clientSideCallContext);
+		assertThat(resultServiceId, is(serviceId + "_0"));
+
+		RoutingStatsCollectorForTest routingStatsService1 = (RoutingStatsCollectorForTest) routerWithStickyFailOverToNextNode.getRoutingStats(serviceIdFailed1);
+		assertThat(routingStatsService1.getFailedCall(), is(1));
+		assertThat(routingStatsService1.getFailedDecision(), is(1));
+		assertThat(routingStatsService1.getRetryDecision(), is(0));
+		assertThat(routingStatsService1.getRequestRoutedTo(), is(0));
+		assertThat(routingStatsService1.getBlacklisted(), is(1));
+
+		RoutingStatsCollectorForTest routingStatsService2 = (RoutingStatsCollectorForTest) routerWithStickyFailOverToNextNode.getRoutingStats(serviceIdFailed2);
+		assertThat(routingStatsService2.getFailedCall(), is(1));
+		assertThat(routingStatsService2.getFailedDecision(), is(1));
+		assertThat(routingStatsService2.getRetryDecision(), is(0));
+		assertThat(routingStatsService2.getRequestRoutedTo(), is(0));
+		assertThat(routingStatsService2.getBlacklisted(), is(1));
+
+		RoutingStatsCollectorForTest routingStatsService0 = (RoutingStatsCollectorForTest) routerWithStickyFailOverToNextNode.getRoutingStats(resultServiceId);
+		assertThat(routingStatsService0.getFailedCall(), is(0));
+		assertThat(routingStatsService0.getFailedDecision(), is(0));
+		assertThat(routingStatsService0.getRetryDecision(), is(0));
+		assertThat(routingStatsService0.getRequestRoutedTo(), is(1));
+		assertThat(routingStatsService0.getBlacklisted(), is(0));
+	}
+
 	private static class Router extends AbstractRouterWithStickyFailOverToNextNode {
+
+		Map<String, RoutingStatsCollector> statsCollectorMap = new HashMap<>();
 
 		@Override
 		protected boolean failingSupported() {
@@ -49,6 +202,19 @@ public class AbstractRouterWithStickyFailOverToNextNodeTest {
 		@Override
 		protected long getModableValue(Object parameter) {
 			return 0;
+		}
+
+		@Override
+		protected RoutingStatsCollector getRoutingStats(final String serviceId) {
+			if (!statsCollectorMap.containsKey(serviceId)) {
+				statsCollectorMap.put(serviceId, new RoutingStatsCollectorForTest());
+			}
+			return statsCollectorMap.get(serviceId);
+		}
+
+		@Override
+		protected int getRandomInt(final int length) {
+			return 1;
 		}
 	}
 

--- a/distributeme-core/src/test/java/org/distributeme/core/routing/RoutingStatsCollectorForTest.java
+++ b/distributeme-core/src/test/java/org/distributeme/core/routing/RoutingStatsCollectorForTest.java
@@ -1,0 +1,57 @@
+package org.distributeme.core.routing;
+
+import org.distributeme.core.stats.RoutingStatsCollector;
+
+public class RoutingStatsCollectorForTest implements RoutingStatsCollector {
+
+	private int failedCall = 0;
+	private int failedDecision = 0;
+	private int retryDecision = 0;
+	private int requestRoutedTo = 0;
+	private int blacklisted = 0;
+
+	@Override
+	public void addFailedCall() {
+		failedCall++;
+	}
+
+	@Override
+	public void addFailDecision() {
+		failedDecision++;
+	}
+
+	@Override
+	public void addRetryDecision() {
+		retryDecision++;
+	}
+
+	@Override
+	public void addRequestRoutedTo() {
+		requestRoutedTo++;
+	}
+
+	@Override
+	public void addBlacklisted() {
+		blacklisted++;
+	}
+
+	public int getFailedCall() {
+		return failedCall;
+	}
+
+	public int getFailedDecision() {
+		return failedDecision;
+	}
+
+	public int getRetryDecision() {
+		return retryDecision;
+	}
+
+	public int getRequestRoutedTo() {
+		return requestRoutedTo;
+	}
+
+	public int getBlacklisted() {
+		return blacklisted;
+	}
+}

--- a/distributeme-core/src/test/resources/blacklisting-routing-test-three-services.json
+++ b/distributeme-core/src/test/resources/blacklisting-routing-test-three-services.json
@@ -1,0 +1,6 @@
+{
+	"numberOfInstances": 3,
+	"blacklistTime": 5000000,
+	"overrideBlacklistIfAllBlacklisted": true,
+	"blacklistStrategyClazz": "org.distributeme.core.routing.blacklisting.DefaultBlacklistingStrategy"
+}

--- a/distributeme-core/src/test/resources/blacklisting-routing-test-two-services.json
+++ b/distributeme-core/src/test/resources/blacklisting-routing-test-two-services.json
@@ -1,0 +1,6 @@
+{
+	"numberOfInstances": 2,
+	"blacklistTime": 5000000,
+	"overrideBlacklistIfAllBlacklisted": true,
+	"blacklistStrategyClazz": "org.distributeme.core.routing.blacklisting.DefaultBlacklistingStrategy"
+}

--- a/distributeme-test/src/main/resources/distributeme.json
+++ b/distributeme-test/src/main/resources/distributeme.json
@@ -1,6 +1,4 @@
 {
 	"registryContainerHost": "127.0.0.1",
 	"registryContainerPort": 9229
-	
-
-} 
+}

--- a/distributeme-test/start.sh
+++ b/distributeme-test/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export VERSION=2.3.2-SNAPSHOT
+export VERSION=2.3.3-SNAPSHOT
 
 CLASSPATH=src/test/resources:target/distributeme-test-$VERSION-jar-with-dependencies.jar
 echo CLASSPATH: $CLASSPATH


### PR DESCRIPTION
- add a test that shows counting problems (**TEST CURRENTLY FAILS**)
- add logger to strategies to separate fail information from blacklisting info